### PR TITLE
Cache expiration after 2 hours

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ type Created = std::time::SystemTime; //epoch
 struct CriteriaCache {
     cache: HashMap<Site, (Stratifiers, Created)>,
 }
-const CRITERIACACHE_TTL: Duration = Duration::from_secs(86400); //cached criteria expire after 24h
+const CRITERIACACHE_TTL: Duration = Duration::from_secs(7200); //cached criteria expire after 2h
 
 #[derive(Clone)]
 struct SharedState {


### PR DESCRIPTION
BHs restart every day because of the nightly build of beam proxy or whatever, and people are disturbed because of differently obfuscated numbers in Prism (which caches for 24 hours) and what BHs return, so we will try to make cache expire after 2h